### PR TITLE
added the dependency to langauge-lua

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,7 @@
       }
     }
   },
-  "dependencies": {}
+  "dependencies": {
+    "language-lua": "^0.9.4"
+  }
 }


### PR DESCRIPTION
Not sure about the exact working version, but 0.9.4 works fine and it looks like 0.9.5 is also already out.
Please test, since I use atom only occasionally and I'm not that deep into plugin dev :-)
